### PR TITLE
add --read-only flag which prevents all writes

### DIFF
--- a/bin/remixd
+++ b/bin/remixd
@@ -10,6 +10,7 @@ program
 .usage('-s <shared folder>')
 .description('Provide a two ways connection between the local computer and Remix IDE')
 .option('-s, --shared-folder <path>', 'Folder to share with Remix IDE')
+.option('--read-only', 'Treat shared folder as read-only (experimental)')
 .option('-m, --mist', 'start mist')
 .option('-g, --geth', 'start geth')
 .option('-p, --dev-path <dev-path>', 'Folder used by mist/geth to start the development instance')
@@ -48,7 +49,7 @@ if (program.sharedFolder) {
   var sharedFolderrouter = new Router(65520, servicesList['sharedfolder'], (webSocket) => {
     servicesList['sharedfolder'].setWebSocket(webSocket)
     servicesList['sharedfolder'].setupNotifications(program.sharedFolder)
-    servicesList['sharedfolder'].sharedFolder(program.sharedFolder)
+    servicesList['sharedfolder'].sharedFolder(program.sharedFolder, program.readOnly)
   })
   killCallBack.push(sharedFolderrouter.start())
 }

--- a/src/services/sharedFolder.js
+++ b/src/services/sharedFolder.js
@@ -12,8 +12,9 @@ module.exports = {
     this.websocket = websocket
   },
 
-  sharedFolder: function (sharedFolder) {
+  sharedFolder: function (sharedFolder, readOnly) {
     this.sharedFolder = sharedFolder
+    this.readOnly = readOnly
   },
 
   list: function (args, cb) {
@@ -62,6 +63,7 @@ module.exports = {
   },
 
   set: function (args, cb) {
+    if (this.readOnly) return cb('Cannot write file: read-only mode selected')
     var path = utils.absolutePath(args.path, this.sharedFolder)
     if (fs.existsSync(path) && !isRealPath(path, cb)) return
     if (args.content === 'undefined') { // no !!!!!
@@ -76,6 +78,7 @@ module.exports = {
   },
 
   rename: function (args, cb) {
+    if (this.readOnly) return cb('Cannot rename file: read-only mode selected')
     var oldpath = utils.absolutePath(args.oldPath, this.sharedFolder)
     if (!fs.existsSync(oldpath)) {
       return cb('File not found ' + oldpath)
@@ -89,6 +92,7 @@ module.exports = {
   },
 
   remove: function (args, cb) {
+    if (this.readOnly) return cb('Cannot remove file: read-only mode selected')
     var path = utils.absolutePath(args.path, this.sharedFolder)
     if (!fs.existsSync(path)) {
       return cb('File not found ' + path)


### PR DESCRIPTION
Implements #8 by preventing file writes, renames, and deletions. Instead it returns with an error (rather than silently ignoring the operation).

This means that the interaction with Remix IDE isn’t exactly graceful: There’s no indication of the read-only mode in the IDE. Ideally, this would be a setting that the user can change on the fly in the IDE settings pane, rather than a CLI flag for remixd. That would require deeper changes.