### PR TITLE
Don’t always display the --help text on start

### DIFF
--- a/bin/remixd
+++ b/bin/remixd
@@ -19,8 +19,9 @@ program
 .option('-r, --rpc <cors-domains>', 'start rpc server. Values are CORS domain')
 .option('-rp, --rpc-port', 'rpc server port (default 8545)')
 .option('--profiler', 'start profiler service')
-.parse(process.argv)
-console.log('example: --dev-path /home/devchains/chain1 --mist --geth --frontend /home/frontend --frontend-port 8084 --auto-mine')
+.on('--help', function(){
+  console.log('\nExample:\n\n    remixd --dev-path /home/devchains/chain1 --mist --geth --frontend /home/frontend --frontend-port 8084 --auto-mine')
+}).parse(process.argv)
 program.outputHelp()
 
 var killCallBack = []

--- a/bin/remixd
+++ b/bin/remixd
@@ -22,7 +22,6 @@ program
 .on('--help', function(){
   console.log('\nExample:\n\n    remixd --dev-path /home/devchains/chain1 --mist --geth --frontend /home/frontend --frontend-port 8084 --auto-mine')
 }).parse(process.argv)
-program.outputHelp()
 
 var killCallBack = []
 


### PR DESCRIPTION
Doing so is confusing (at least to me), since it generally implies that the user entered an invalid option.

I’ve also moved the example invocation into the help text as described in the commander docs.